### PR TITLE
Upgrades to components and supports version 3.4 of the context.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
         <codehaus.build-helper.plugin.version>1.10</codehaus.build-helper.plugin.version>
-        <fabric8.docker.maven.plugin.version>0.24.0</fabric8.docker.maven.plugin.version>
+        <fabric8.docker.maven.plugin.version>0.30.0</fabric8.docker.maven.plugin.version>
         <git-commit-plugin.version>2.2.4</git-commit-plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <slf4j.version>1.7.25</slf4j.version>
@@ -138,12 +138,12 @@
         <sword2-client.version>0.9.3</sword2-client.version>
         <mets-api.version>1.3.0</mets-api.version>
         <tika.version>1.17</tika.version>
-        <pass-client.version>0.5.0</pass-client.version>
+        <pass-client.version>0.6.0</pass-client.version>
         <fast-classpath-scanner.version>3.1.5</fast-classpath-scanner.version>
         <jackson.version>2.9.6</jackson.version>
 
-        <docker.fcrepo.version>oapass/fcrepo:4.7.5-3.2-1</docker.fcrepo.version>
-        <docker.indexer.version>oapass/indexer:0.0.17-3.2-SNAPSHOT</docker.indexer.version>
+        <docker.fcrepo.version>oapass/fcrepo:4.7.5-3.4</docker.fcrepo.version>
+        <docker.indexer.version>oapass/indexer:0.0.18-3.4</docker.indexer.version>
         <docker.elasticsearch.version>docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3</docker.elasticsearch.version>
 
         <!-- TODO properly tag these images -->
@@ -151,7 +151,7 @@
         <docker.dspace.version>oapass/dspace:latest</docker.dspace.version>
         <docker.ftp.version>oapass/ftpserver:latest</docker.ftp.version>
 
-        <pass.jsonld.context>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.2.jsonld</pass.jsonld.context>
+        <pass.jsonld.context>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.4.jsonld</pass.jsonld.context>
 
     </properties>
 


### PR DESCRIPTION
- docker-maven-plugin to 0.30.0 from 0.24.0
- PASS Client from 0.5.0 to 0.6.0 (context version 3.4 compatibility)
- fcrepo image to oapass/fcrepo:4.7.5-3.4 (context version 3.4 compatibility)
- indexer image to oapass/indexer:0.0.18-3.4 (context version 3.4 compatibility)