### PR TITLE
 Conditionally persist resources in the repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 sudo: required
 cache:

--- a/cri/src/main/java/org/dataconservancy/pass/support/messaging/cri/CriticalPath.java
+++ b/cri/src/main/java/org/dataconservancy/pass/support/messaging/cri/CriticalPath.java
@@ -33,6 +33,15 @@ import java.util.function.Predicate;
 /**
  * Provides the guarantees set by {@link CriticalRepositoryInteraction}, and boilerplate for interacting with, and
  * modifying the state of, repository resources.
+ * <p>
+ * Note that if any of the {@link #performCritical(URI, Class, Predicate, Predicate, Function) critical}
+ * {@link #performCritical(URI, Class, Predicate, BiPredicate, Function) methods} complete without throwing an
+ * {@code Exception}, this implementation will perform an update of the resource in the repository, <em>even if the
+ * critical method does not change the state of the resource</em>.  Update requests (e.g. implemented as {@code
+ * PATCH} HTTP requests) that do not change the state of the resource are idempotent.  <em>However</em>, each update
+ * request will result in Fedora issuing a JMS message indicating that the resource has been modified, even though the
+ * state of the resource has not changed.
+ * </p>
  *
  * @author Elliot Metsger (emetsger@jhu.edu)
  */
@@ -52,7 +61,7 @@ public class CriticalPath implements CriticalRepositoryInteraction {
 
     /**
      * {@inheritDoc}
-     * <strong>Implementation notes</strong>
+     * <h3>Implementation notes</h3>
      * Executes in order:
      * <ol>
      *     <li>Obtain a lock over the interned, string form of the {@code uri}, insuring no interference from other
@@ -68,6 +77,15 @@ public class CriticalPath implements CriticalRepositoryInteraction {
      *         the interaction is short-circuited, and a {@code CriticalResult} returned.</li>
      *     <li>Apply the post-condition {@code Predicate} and returns {@code CriticalResult}</li>
      * </ol>
+     * <h3>Exception handling</h3>
+     * <p>
+     * All code that executes within this method is executed within {@code try/catch} blocks.  Each lambda passed to
+     * this method executes within a {@code try/catch}, and all supporting code within this method executes within
+     * {@code try/catch} blocks.  If an {@code Exception} is thrown, it will be caught, placed in the {@code
+     * CriticalResult}, and this method immediately returns. The caller is responsible for evaluating the {@code
+     * CriticalResult} and determining success or failure of this method.
+     * </p>
+     *
      * @param uri the uri of the {@code PassEntity} which is the subject of the {@code critical} pathv
      * @param clazz the concrete {@code Class} of the {@code PassEntity} represented by {@code uri}
      * @param precondition precondition that must evaluate to {@code true} for the {@code critical} path to execute
@@ -89,7 +107,7 @@ public class CriticalPath implements CriticalRepositoryInteraction {
 
     /**
      * {@inheritDoc}
-     * <strong>Implementation notes</strong>
+     * <h3>Implementation notes</h3>
      * Executes in order:
      * <ol>
      *     <li>Obtain a lock over the interned, string form of the {@code uri}, insuring no interference from other
@@ -105,6 +123,15 @@ public class CriticalPath implements CriticalRepositoryInteraction {
      *         the interaction is short-circuited, and a {@code CriticalResult} returned.</li>
      *     <li>Apply the post-condition {@code BiPredicate} and returns {@code CriticalResult}</li>
      * </ol>
+     * <h3>Exception handling</h3>
+     * <p>
+     * All code that executes within this method is executed within {@code try/catch} blocks.  Each lambda passed to
+     * this method executes within a {@code try/catch}, and all supporting code within this method executes within
+     * {@code try/catch} blocks.  If an {@code Exception} is thrown, it will be caught, placed in the {@code
+     * CriticalResult}, and this method immediately returns. The caller is responsible for evaluating the {@code
+     * CriticalResult} and determining success or failure of this method.
+     * </p>
+     *
      * @param uri the uri of the {@code PassEntity} which is the subject of the {@code critical} pathv
      * @param clazz the concrete {@code Class} of the {@code PassEntity} represented by {@code uri}
      * @param precondition precondition that must evaluate to {@code true} for the {@code critical} path to execute

--- a/cri/src/main/java/org/dataconservancy/pass/support/messaging/cri/CriticalPath.java
+++ b/cri/src/main/java/org/dataconservancy/pass/support/messaging/cri/CriticalPath.java
@@ -34,13 +34,14 @@ import java.util.function.Predicate;
  * Provides the guarantees set by {@link CriticalRepositoryInteraction}, and boilerplate for interacting with, and
  * modifying the state of, repository resources.
  * <p>
- * Note that if any of the {@link #performCritical(URI, Class, Predicate, Predicate, Function) critical}
- * {@link #performCritical(URI, Class, Predicate, BiPredicate, Function) methods} complete without throwing an
- * {@code Exception}, this implementation will perform an update of the resource in the repository, <em>even if the
- * critical method does not change the state of the resource</em>.  Update requests (e.g. implemented as {@code
- * PATCH} HTTP requests) that do not change the state of the resource are idempotent.  <em>However</em>, each update
- * request will result in Fedora issuing a JMS message indicating that the resource has been modified, even though the
- * state of the resource has not changed.
+ * Note that the {@link #performCritical(URI, Class, Predicate, Predicate, Function) critical}
+ * {@link #performCritical(URI, Class, Predicate, BiPredicate, Function) methods} may modify the state of a resource.
+ * If the the critical method modifies resource state (tested according to {@link PassEntity#hashCode()}), the resource
+ * will be persisted in the repository.  Likewise, if the critical method does <em>not</em> modify resource state, it
+ * will <em>not</em> attempt to persist the resource (since there are no changes to persist).  Even though update
+ * requests (e.g. implemented as {@code PATCH} HTTP requests) that do not change the state of the resource are
+ * idempotent, Fedora issues a JMS message indicating that the resource has been modified.  This happens despite the
+ * "business" state of the resource having not been changed.
  * </p>
  *
  * @author Elliot Metsger (emetsger@jhu.edu)
@@ -72,9 +73,11 @@ public class CriticalPath implements CriticalRepositoryInteraction {
      *         {@code CriticalResult} if the condition fails</li>
      *     <li>Perform the {@code critical} interaction, short-circuiting the interaction by returning a
      *         {@code CriticalResult} if an {@code Exception} is thrown</li>
-     *     <li>Update the resource, and re-read it from the repository.  If a {@code ConflictUpdateException} is thrown,
-     *         it is supplied to the {@link ConflictHandler} for resolution.  If any other {@code Exception} is thrown,
-     *         the interaction is short-circuited, and a {@code CriticalResult} returned.</li>
+     *     <li>If the {@code critical} interaction modifies the resource, update the resource in the repository.  Read
+     *         the resource from the repository (even if no update is performed).  If a {@code ConflictUpdateException}
+     *         is thrown during the update, it is supplied to the {@link ConflictHandler} for resolution.  If any other
+     *         {@code Exception} is thrown, the interaction is short-circuited, and a {@code CriticalResult}
+     *         returned.</li>
      *     <li>Apply the post-condition {@code Predicate} and returns {@code CriticalResult}</li>
      * </ol>
      * <h3>Exception handling</h3>
@@ -118,9 +121,11 @@ public class CriticalPath implements CriticalRepositoryInteraction {
      *         {@code CriticalResult} if the condition fails</li>
      *     <li>Perform the {@code critical} interaction, short-circuiting the interaction by returning a
      *         {@code CriticalResult} if an {@code Exception} is thrown</li>
-     *     <li>Update the resource, and re-read it from the repository.  If a {@code ConflictUpdateException} is thrown,
-     *         it is supplied to the {@link ConflictHandler} for resolution.  If any other {@code Exception} is thrown,
-     *         the interaction is short-circuited, and a {@code CriticalResult} returned.</li>
+     *     <li>If the {@code critical} interaction modifies the resource, update the resource in the repository.  Read
+     *         the resource from the repository (even if no update is performed).  If a {@code ConflictUpdateException}
+     *         is thrown during the update, it is supplied to the {@link ConflictHandler} for resolution.  If any other
+     *         {@code Exception} is thrown, the interaction is short-circuited, and a {@code CriticalResult}
+     *         returned.</li>
      *     <li>Apply the post-condition {@code BiPredicate} and returns {@code CriticalResult}</li>
      * </ol>
      * <h3>Exception handling</h3>
@@ -180,8 +185,11 @@ public class CriticalPath implements CriticalRepositoryInteraction {
             // 4.  Apply the critical update to the resource.
 
             R updateResult = null;
+            boolean updated = false;  // records whether the critical Function alters the state of the resource
             try {
+                int before = resource.hashCode();
                 updateResult = critical.apply(resource);
+                updated = before != resource.hashCode();
             } catch (Exception e) {
                 return new CriticalResult<>(updateResult, resource,false, e);
             }
@@ -191,7 +199,14 @@ public class CriticalPath implements CriticalRepositoryInteraction {
             // TODO: update this class to allow the ConflictHandler to be pluggable
 
             try {
-                resource = passClient.updateAndReadResource(resource, (Class<T>)resource.getClass());
+                // Avoid updating the resource if it has not been changed by the critical Function.  Updates that don't
+                // modify resource state are idempotent, but Fedora will emit a JMS message for the update, even if no
+                // state has changed (merely touch(1)-ing the resource will result in the emission of a JMS message).
+                if (updated) {
+                    resource = passClient.updateAndReadResource(resource, (Class<T>)resource.getClass());
+                } else {
+                    resource = passClient.readResource(resource.getId(), (Class<T>) resource.getClass());
+                }
             } catch (UpdateConflictException e) {
                 try {
                     // If the ConflictHandler is successful, the resource with its updated state is returned

--- a/cri/src/main/java/org/dataconservancy/pass/support/messaging/cri/DefaultConflictHandler.java
+++ b/cri/src/main/java/org/dataconservancy/pass/support/messaging/cri/DefaultConflictHandler.java
@@ -62,7 +62,7 @@ public class DefaultConflictHandler implements ConflictHandler {
     public <T extends PassEntity, R> R handleConflict(T conflictedResource, Class<T> resourceClass, Predicate<T>
             preCondition, Function<T, R> criticalUpdate) {
 
-        LOG.debug(">>>> Retrying update for {}, version {}",
+        LOG.trace("Retrying update for {}, version {}",
                 conflictedResource.getId(), conflictedResource.getVersionTag());
 
         T toUpdate = null;
@@ -72,7 +72,7 @@ public class DefaultConflictHandler implements ConflictHandler {
             String msg = String.format("Update retry failed for %s (version %s): Unable to successfully re-read the " +
                             "latest version of the resource when retrying: %s", conflictedResource.getId(),
                     conflictedResource.getVersionTag(), e.getMessage());
-            LOG.info(msg, e);
+            LOG.debug(msg, e);
         }
 
         try {
@@ -88,7 +88,7 @@ public class DefaultConflictHandler implements ConflictHandler {
         } catch (Exception e) {
             String msg = String.format("Update retry failed for %s (version %s to %s)",
                     conflictedResource.getId(), conflictedResource.getVersionTag(), toUpdate.getVersionTag());
-            LOG.info(msg, e);
+            LOG.debug(msg, e);
         }
 
         return null;


### PR DESCRIPTION
Prior to this PR, `CriticalPath` would _always_ update the resource in the repository, even if the critical `Function` didn't modify its state locally.  

Updates (in the form of HTTP PATCH) whose state is equivalent to the repository state are "idempotent", but they do result in Fedora emitting a modification JMS event for each update.  This happens despite the fact that the "business state" of the object remains unchanged ("business state" distinguished from other properties of the resource such as the Fedora-managed properties).

These spurious JMS events can result in endless loops in the Deposit Services code, whereby an update to a Deposit Resource results in a JMS event, Deposit Services processes the event and updates the Deposit Resource, which results in a JMS event...

These loops happen when a Deposit resource has an _intermediate_ deposit status like `submitted`, and the DS code performs an update of the resource in the repository even though its status has not changed locally.  The loop is broken when the DS code updates the Deposit resource to a _terminal_ state.  To avoid endless processing of Deposits with _intermediate_ statuses, Deposit Services should conditionally update the Deposit only when its status changes.

This library is used by Deposit Services to perform updates to all `PassEntity` objects, including `Deposit`s.  By updating this library to conditionally perform updates to repository resources, endless loops as described above will be prevented.

